### PR TITLE
Support manual control of heating via overlays

### DIFF
--- a/client.go
+++ b/client.go
@@ -57,15 +57,20 @@ func (c *Client) WithCredentials(ctx context.Context, username, password string)
 	return c, nil
 }
 
-// Request performs an HTTP request to the tado° API
-func (c *Client) Request(method, url string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest(method, url, body)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create tado° API request: %w", err)
-	}
+// Do sends the given HTTP request to the tado° API.
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("unable to talk to tado° API: %w", err)
 	}
 	return resp, nil
+}
+
+// Request performs an HTTP request to the tado° API
+func (c *Client) Request(method, url string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create http request: %w", err)
+	}
+	return c.Do(req)
 }

--- a/examples/overlay/main.go
+++ b/examples/overlay/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/gonzolino/gotado"
+)
+
+const (
+	clientID     = "tado-web-app"
+	clientSecret = "wZaRN7rpjn3FoNyF5IFuxg9uMzYJcvOoQ8QWiIqS3hfk6gLhVlG57j5YNoZL2Rtc"
+)
+
+func main() {
+	// Get credentials from env vars
+	username, ok := os.LookupEnv("TADO_USERNAME")
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Variable TADO_USERNAME not set\n")
+		os.Exit(1)
+	}
+	password, ok := os.LookupEnv("TADO_PASSWORD")
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Variable TADO_PASSWORD not set\n")
+		os.Exit(1)
+	}
+
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "Usage: %s homeName zoneName\n", os.Args[0])
+		os.Exit(1)
+	}
+	homeName, zoneName := os.Args[1], os.Args[2]
+
+	ctx := context.Background()
+
+	// Create authenticated tado° client
+	client := gotado.NewClient(clientID, clientSecret).WithTimeout(5 * time.Second)
+	client, err := client.WithCredentials(ctx, username, password)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Authentication failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	user, err := gotado.GetMe(client)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get user info: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Find the home to control
+	var home *gotado.UserHome
+	for _, h := range user.Homes {
+		if h.Name == homeName {
+			home = &h
+			break
+		}
+	}
+	if home == nil {
+		fmt.Fprintf(os.Stderr, "Home '%s' not found\n", homeName)
+		os.Exit(1)
+	}
+
+	// Find zone to control
+	zones, err := gotado.GetZones(client, home)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get zones: %v\n", err)
+		os.Exit(1)
+	}
+	var zone *gotado.Zone
+	for _, z := range zones {
+		if z.Name == zoneName {
+			zone = z
+			break
+		}
+	}
+	if zone == nil {
+		fmt.Fprintf(os.Stderr, "Zone '%s' not found\n", zoneName)
+		os.Exit(1)
+	}
+
+	// Set heating off in zone
+	if err := gotado.SetZoneOverlayHeatingOff(client, home, zone); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to turn off heating: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Turned off heating in home '%s', zone '%s'\n", home.Name, zone.Name)
+	time.Sleep(30 * time.Second)
+
+	// Set heating on in zone (unit for temperature matches default unit of home)
+	overlay, err := gotado.SetZoneOverlayHeatingOn(client, home, zone, 25)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to turn heating to 25 degrees: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Turned heating in home '%s', zone '%s' to %f°C\n", home.Name, zone.Name, overlay.Setting.Temperature.Celsius)
+	time.Sleep(30 * time.Second)
+
+	// Turn off manual heating control in zone. Return to smart schedule
+	if err := gotado.DeleteZoneOverlay(client, home, zone); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to turn off manual heating: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Turned heating in home '%s', zone '%s' back to smart schedule\n", home.Name, zone.Name)
+}

--- a/tado.go
+++ b/tado.go
@@ -1,7 +1,9 @@
 package gotado
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -109,10 +111,10 @@ type ZoneState struct {
 	GeolocationOverride bool   `json:"geolocationOverride"`
 	// TODO missing geolocationOverrideDisableTime
 	// TODO missing preparation
-	Setting ZoneStateSetting `json:"setting"`
-	// TODO missing overlayType
-	// TODO missing overlay
-	OpenWindow *ZoneStateOpenWindow `json:"openWindow"`
+	Setting     ZoneStateSetting     `json:"setting"`
+	OverlayType *string              `json:"overlayType"`
+	Overlay     *ZoneOverlay         `json:"overlay"`
+	OpenWindow  *ZoneStateOpenWindow `json:"openWindow"`
 	// TODO missing nextScheduleChange
 	// TODO missing nextTimeBlock
 	Link ZoneStateLink `json:"link"`
@@ -131,6 +133,36 @@ type ZoneStateSetting struct {
 type ZoneStateSettingTemperature struct {
 	Celsius    float64 `json:"celsius"`
 	Fahrenheit float64 `json:"fahrenheit"`
+}
+
+// ZoneOverlay holds overlay information of a zone
+type ZoneOverlay struct {
+	Type        string                  `json:"type,omitempty"`
+	Setting     ZoneOverlaySetting      `json:"setting"`
+	Termination *ZoneOverlayTermination `json:"termination,omitempty"`
+}
+
+// ZoneOverlaySetting holds the setting of a zone overlay
+type ZoneOverlaySetting struct {
+	Type        string                         `json:"type"`
+	Power       string                         `json:"power"`
+	Temperature *ZoneOverlaySettingTemperature `json:"temperature,omitempty"`
+}
+
+// ZoneOverlaySettingTemperature holds the temperature of a zone state setting
+type ZoneOverlaySettingTemperature struct {
+	Celsius    float64 `json:"celsius"`
+	Fahrenheit float64 `json:"fahrenheit"`
+}
+
+// ZoneOverlayTermination holdes the termination information of a zone overlay
+type ZoneOverlayTermination struct {
+	Type                   string  `json:"type"`
+	TypeSkillBasedApp      string  `json:"typeSkillBasedApp"`
+	DurationInSeconds      int32   `json:"durationInSeconds,omitempty"`
+	Expiry                 string  `json:"expiry,omitempty"`
+	RemainingTimeInSeconds int32   `json:"remainingTimeInSeconds,omitempty"`
+	ProjectedExpiry        *string `json:"projectedExpiry"`
 }
 
 // ZoneStateOpenWindow holds the information about an open window of a zone state
@@ -265,6 +297,103 @@ func GetZoneState(client *Client, userHome *UserHome, zone *Zone) (*ZoneState, e
 	}
 
 	return zoneState, nil
+}
+
+// setZoneOverlay sets a zone overlay setting
+func setZoneOverlay(client *Client, userHome *UserHome, zone *Zone, overlay ZoneOverlay) (*ZoneOverlay, error) {
+	data, err := json.Marshal(overlay)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal zone overlay: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPut, apiURL("homes/%d/zones/%d/overlay", userHome.ID, zone.ID), bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create http request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json;charset=utf-8")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := isError(resp); err != nil {
+		return nil, fmt.Errorf("tado° API error: %w", err)
+	}
+
+	respOverlay := &ZoneOverlay{}
+	if err := json.NewDecoder(resp.Body).Decode(&respOverlay); err != nil {
+		return nil, fmt.Errorf("unable to decode tado° API response: %w", err)
+	}
+
+	return respOverlay, nil
+}
+
+// SetZoneOverlayHeatingOff turns off heating in a zone
+func SetZoneOverlayHeatingOff(client *Client, userHome *UserHome, zone *Zone) error {
+	setOverlay := ZoneOverlay{
+		Setting: ZoneOverlaySetting{
+			Type:  "HEATING",
+			Power: "OFF",
+		},
+	}
+	overlay, err := setZoneOverlay(client, userHome, zone, setOverlay)
+	if err != nil {
+		return err
+	}
+
+	if overlay.Type != "MANUAL" || overlay.Setting.Power != "OFF" {
+		return errors.New("tado° did not accept new overlay")
+	}
+
+	return nil
+}
+
+// SetZoneOverlayHeatingOn turns on heating in a zone. The temperature should
+// use the unit configured for the home. Returns the resulting overlay if successful.
+func SetZoneOverlayHeatingOn(client *Client, userHome *UserHome, zone *Zone, temperature float64) (*ZoneOverlay, error) {
+	home, err := GetHome(client, userHome)
+	if err != nil || home == nil {
+		return nil, fmt.Errorf("unable to determine temperature unit")
+	}
+	temperatureSetting := &ZoneOverlaySettingTemperature{}
+	switch home.TemperatureUnit {
+	case "CELSIUS":
+		temperatureSetting.Celsius = temperature
+	case "FAHRENHEIT":
+		temperatureSetting.Fahrenheit = temperature
+	default:
+		return nil, fmt.Errorf("invalid temperature unit '%s'", home.TemperatureUnit)
+	}
+
+	setOverlay := ZoneOverlay{
+		Setting: ZoneOverlaySetting{
+			Type:        "HEATING",
+			Power:       "ON",
+			Temperature: temperatureSetting,
+		},
+	}
+	overlay, err := setZoneOverlay(client, userHome, zone, setOverlay)
+	if err != nil {
+		return nil, err
+	}
+
+	if overlay.Type != "MANUAL" || overlay.Setting.Power != "ON" {
+		return overlay, errors.New("tado° did not accept new overlay")
+	}
+
+	return overlay, nil
+}
+
+// DeleteZoneOverlay removes an overlay from a zone, thereby returning a zone to smart schedule
+func DeleteZoneOverlay(client *Client, userHome *UserHome, zone *Zone) error {
+	resp, err := client.Request(http.MethodDelete, apiURL("homes/%d/zones/%d/overlay", userHome.ID, zone.ID), nil)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("unexpected tado° API response status: %s", resp.Status)
+	}
+	return nil
 }
 
 // SetWindowOpen marks the window in a zone as open (open window must have been detected before)


### PR DESCRIPTION
Fix #10

This PR adds the methods `SetZoneOverlayHeatingOff`, `SetZoneOverlayHeatingOn` and `DeleteZoneOverlay` to control heating manually via overlays. It also adds some example code to show the functionality.