### PR TITLE
Allow control of presence

### DIFF
--- a/examples/presence/main.go
+++ b/examples/presence/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/gonzolino/gotado"
+)
+
+const (
+	clientID     = "tado-web-app"
+	clientSecret = "wZaRN7rpjn3FoNyF5IFuxg9uMzYJcvOoQ8QWiIqS3hfk6gLhVlG57j5YNoZL2Rtc"
+)
+
+func main() {
+	// Get credentials from env vars
+	username, ok := os.LookupEnv("TADO_USERNAME")
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Variable TADO_USERNAME not set\n")
+		os.Exit(1)
+	}
+	password, ok := os.LookupEnv("TADO_PASSWORD")
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Variable TADO_PASSWORD not set\n")
+		os.Exit(1)
+	}
+
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s homeName\n", os.Args[0])
+		os.Exit(1)
+	}
+	homeName := os.Args[1]
+
+	ctx := context.Background()
+
+	// Create authenticated tado° client
+	client := gotado.NewClient(clientID, clientSecret).WithTimeout(5 * time.Second)
+	client, err := client.WithCredentials(ctx, username, password)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Authentication failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	user, err := gotado.GetMe(client)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get user info: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Find the home to control
+	var home *gotado.UserHome
+	for _, h := range user.Homes {
+		if h.Name == homeName {
+			home = &h
+			break
+		}
+	}
+	if home == nil {
+		fmt.Fprintf(os.Stderr, "Home '%s' not found\n", homeName)
+		os.Exit(1)
+	}
+
+	// Get current presence from home state
+	state, err := gotado.GetHomeState(client, home)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get home state: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Presence: %s\nPresence Locked: %t\n", state.Presence, state.PresenceLocked)
+}

--- a/examples/presence/main.go
+++ b/examples/presence/main.go
@@ -68,5 +68,52 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Failed to get home state: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Printf("Presence: %s\nPresence Locked: %t\n", state.Presence, state.PresenceLocked)
+	fmt.Printf("Initial Presence: %s", state.Presence)
+	if state.PresenceLocked {
+		fmt.Printf(" (locked)\n")
+	} else {
+		fmt.Println()
+	}
+
+	// Lock presence to 'away'
+	if err := gotado.SetPresenceAway(client, home); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to set presence 'away': %v", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Set presence away")
+	time.Sleep(10 * time.Second)
+
+	// Lock presence to 'at home'
+	if err := gotado.SetPresenceHome(client, home); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to set presence 'home': %v", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Set presence home")
+	time.Sleep(10 * time.Second)
+
+	// Set auto presence
+	if err := gotado.SetPresenceAuto(client, home); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to set presence 'auto': %v", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Set presence auto")
+	time.Sleep(10 * time.Second)
+
+	// Return to initial presence settings
+	if state.PresenceLocked {
+		switch state.Presence {
+		case "HOME":
+			err = gotado.SetPresenceHome(client, home)
+		case "AWAY":
+			err = gotado.SetPresenceAway(client, home)
+		}
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to return to initial presence settings: %v", err)
+			os.Exit(1)
+		}
+	}
 }

--- a/tado.go
+++ b/tado.go
@@ -77,6 +77,12 @@ type HomeGeolocation struct {
 	Longitude float64 `json:"longitude"`
 }
 
+// HomeState represents the state of a tado° home
+type HomeState struct {
+	Presence       string `json:"presence"`
+	PresenceLocked bool   `json:"presenceLocked"`
+}
+
 // Zone represents a tado° zone
 type Zone struct {
 	ID          int32    `json:"id"`
@@ -285,6 +291,26 @@ func GetHome(client *Client, userHome *UserHome) (*Home, error) {
 	}
 
 	return home, nil
+}
+
+// GetHomeState returns the state of the given home
+func GetHomeState(client *Client, userHome *UserHome) (*HomeState, error) {
+	resp, err := client.Request(http.MethodGet, apiURL("homes/%d/state", userHome.ID), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := isError(resp); err != nil {
+		return nil, fmt.Errorf("tado° API error: %w", err)
+	}
+
+	homeState := &HomeState{}
+	if err := json.NewDecoder(resp.Body).Decode(homeState); err != nil {
+		return nil, fmt.Errorf("unable to decode tado° API response: %w", err)
+	}
+
+	return homeState, nil
 }
 
 // GetZones returns information about the zones in the given home


### PR DESCRIPTION
tado allows to track the presence in a home via geofencing ("auto mode"). For
manual control of presence, tado allows to "lock" the presence to either 'home'
or 'away'. This PR adds functions to read the presence and presence lock state
from a home, as well as functions to control the presence. All three modes,
"auto", "home" and "away", are supported.

Fix #19.
