### PR TITLE
Support control of early start settings

### DIFF
--- a/examples/earlystart/main.go
+++ b/examples/earlystart/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/gonzolino/gotado"
+)
+
+const (
+	clientID     = "tado-web-app"
+	clientSecret = "wZaRN7rpjn3FoNyF5IFuxg9uMzYJcvOoQ8QWiIqS3hfk6gLhVlG57j5YNoZL2Rtc"
+)
+
+func main() {
+	// Get credentials from env vars
+	username, ok := os.LookupEnv("TADO_USERNAME")
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Variable TADO_USERNAME not set\n")
+		os.Exit(1)
+	}
+	password, ok := os.LookupEnv("TADO_PASSWORD")
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Variable TADO_PASSWORD not set\n")
+		os.Exit(1)
+	}
+
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "Usage: %s homeName zoneName\n", os.Args[0])
+		os.Exit(1)
+	}
+	homeName, zoneName := os.Args[1], os.Args[2]
+
+	ctx := context.Background()
+
+	// Create authenticated tado° client
+	client := gotado.NewClient(clientID, clientSecret).WithTimeout(5 * time.Second)
+	client, err := client.WithCredentials(ctx, username, password)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Authentication failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	user, err := gotado.GetMe(client)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get user info: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Find the home to control
+	var home *gotado.UserHome
+	for _, h := range user.Homes {
+		if h.Name == homeName {
+			home = &h
+			break
+		}
+	}
+	if home == nil {
+		fmt.Fprintf(os.Stderr, "Home '%s' not found\n", homeName)
+		os.Exit(1)
+	}
+
+	// Find zone to control
+	zones, err := gotado.GetZones(client, home)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get zones: %v\n", err)
+		os.Exit(1)
+	}
+	var zone *gotado.Zone
+	for _, z := range zones {
+		if z.Name == zoneName {
+			zone = z
+			break
+		}
+	}
+	if zone == nil {
+		fmt.Fprintf(os.Stderr, "Zone '%s' not found\n", zoneName)
+		os.Exit(1)
+	}
+
+	// Check if early start is currently enabled for zone
+	earlyStartEnabled, err := gotado.IsEarlyStartEnabled(client, home, zone)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to check if early start is enabled: %v\n", err)
+		os.Exit(1)
+	}
+	if earlyStartEnabled {
+		fmt.Println("Early start is enabled")
+	} else {
+		fmt.Println("Early start is disabled")
+	}
+
+	// Toggle early start setting
+	if earlyStartEnabled {
+		err = gotado.DisableEarlyStart(client, home, zone)
+	} else {
+		err = gotado.EnableEarlyStart(client, home, zone)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to toggle early start: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Toggled early start")
+	time.Sleep(10 * time.Second)
+
+	// Toggle early start back to original value
+	if earlyStartEnabled {
+		err = gotado.EnableEarlyStart(client, home, zone)
+	} else {
+		err = gotado.DisableEarlyStart(client, home, zone)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to return to initial early start settings: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Add functions to enable or disable the early start settings of zones, as well
as to check their current setting.

Fix #23.
