### PR TITLE
Push test coverage data to deepsource after PR merged

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -4,18 +4,24 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types:
-      - edited
-      - opened
-      - synchronize
-      - reopened
-    branches:
-      - main
   schedule:
     - cron: "19 7 * * 2"
 
 jobs:
+  go-test:
+    name: Go Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - run: go test -coverprofile=cover.out -v ./...
+      - uses: deepsourcelabs/test-coverage-action@v1.0.0
+        with:
+          key: go
+          coverage-file: cover.out
+          dsn: ${{ secrets.DEEPSOURCE_DSN }}
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,6 @@ name: Test
 
 on:
   pull_request:
-    types:
-      - edited
-      - opened
-      - synchronize
-      - reopened
-    branches:
-      - main
 
 jobs:
   go-test:
@@ -19,9 +12,4 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.16
-      - run: go test -coverprofile=cover.out -v ./...
-      - uses: deepsourcelabs/test-coverage-action@v1.0.0
-        with:
-          key: go
-          coverage-file: cover.out
-          dsn: ${{ secrets.DEEPSOURCE_DSN }}
+      - run: go test -v ./...


### PR DESCRIPTION
Actions that require secrets cause trouble in PRs that are not created by
maintainers. This PR refactors actions so that no secrets are used in PR
actions.
