### PR TITLE
Merge release-please jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,8 @@ on:
       - main
 
 jobs:
-  release-pr:
-    name: Release PR
-    runs-on: ubuntu-latest
-    steps:
-      - uses: GoogleCloudPlatform/release-please-action@v3
-        with:
-          release-type: go
-          package-name: gotado
-          command: release-pr
   release:
-    name: Release
+    name: Release Please
     runs-on: ubuntu-latest
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3
@@ -24,4 +15,3 @@ jobs:
           token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           release-type: go
           package-name: gotado
-          command: github-release


### PR DESCRIPTION
Because the realease-please action was run from the github-actions user, the
test action was not always automatically run.

By introducing a bot user to run release-please, this should hopefully be fixed
and we can merge the release-please jobs again. (The token secret still has the
same name, but it contains a bot token now instead of a personal one).
