### PR TITLE
Set missing v2 import path for go mod

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"reflect"
 
-	oauth2int "github.com/gonzolino/gotado/internal/oauth2"
+	oauth2int "github.com/gonzolino/gotado/v2/internal/oauth2"
 	"golang.org/x/oauth2"
 )
 

--- a/client_test.go
+++ b/client_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	oauth2int "github.com/gonzolino/gotado/internal/oauth2"
+	oauth2int "github.com/gonzolino/gotado/v2/internal/oauth2"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
 )

--- a/examples/away/main.go
+++ b/examples/away/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/gonzolino/gotado"
+	"github.com/gonzolino/gotado/v2"
 )
 
 const (

--- a/examples/earlystart/main.go
+++ b/examples/earlystart/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/gonzolino/gotado"
+	"github.com/gonzolino/gotado/v2"
 )
 
 const (

--- a/examples/me/main.go
+++ b/examples/me/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/gonzolino/gotado"
+	"github.com/gonzolino/gotado/v2"
 )
 
 const (

--- a/examples/mischomeinfo/main.go
+++ b/examples/mischomeinfo/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/gonzolino/gotado"
+	"github.com/gonzolino/gotado/v2"
 )
 
 const (

--- a/examples/overlay/main.go
+++ b/examples/overlay/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/gonzolino/gotado"
+	"github.com/gonzolino/gotado/v2"
 )
 
 const (

--- a/examples/presence/main.go
+++ b/examples/presence/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/gonzolino/gotado"
+	"github.com/gonzolino/gotado/v2"
 )
 
 const (

--- a/examples/schedule/main.go
+++ b/examples/schedule/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/gonzolino/gotado"
+	"github.com/gonzolino/gotado/v2"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gonzolino/gotado
+module github.com/gonzolino/gotado/v2
 
 go 1.18
 


### PR DESCRIPTION
Since release-please labeled the latest version 2.0.0, we need to fix the
import path for the module.
