### PR TITLE
ci: Switch from DeepSource test-coverage-action to CLI

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -16,12 +16,15 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - run: go test -coverprofile=cover.out -v ./...
-      - uses: deepsourcelabs/test-coverage-action@v1.0.4
-        with:
-          key: go
-          coverage-file: cover.out
-          dsn: ${{ secrets.DEEPSOURCE_DSN }}
+      - name: Report test-coverage to DeepSource
+        run: |
+          go test -coverprofile=${COVERAGE_FILE} -v ./...
+          curl https://deepsource.io/cli | sh
+          ./bin/deepsource report --analyzer test-coverage --key $LANGUAGE_KEY --value-file ${COVERAGE_FILE}
+        env:
+          DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
+          COVERAGE_FILE: cover.out
+          LANGUAGE_KEY: go
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest


### PR DESCRIPTION
According to [1] the DeepSource test-coverage-action has been broken by
a recent change in git. This commit replaces the action with a CLI
invocation.

[1]: https://discuss.deepsource.io/t/breaking-deepsource-test-coverage-github-action/507
