### PR TITLE
added home.GetZoneStates API call to retreive the state of all zones with one call

### DIFF
--- a/home.go
+++ b/home.go
@@ -40,7 +40,7 @@ func (h *Home) GetZone(ctx context.Context, name string) (*Zone, error) {
 	return nil, fmt.Errorf("unknown zone name '%s'", name)
 }
 
-// GetZoneStates returns information abaut the states of all zones in the home
+// GetZoneStates returns information about the states of all zones in the home
 func (h *Home) GetZoneStates(ctx context.Context) (*ZoneStates, error) {
 	zoneStates := &ZoneStates{}
 	if err := h.client.get(ctx, apiURL("homes/%d/zoneStates", h.ID), &zoneStates); err != nil {

--- a/home.go
+++ b/home.go
@@ -40,6 +40,15 @@ func (h *Home) GetZone(ctx context.Context, name string) (*Zone, error) {
 	return nil, fmt.Errorf("unknown zone name '%s'", name)
 }
 
+// GetZoneStates returns information abaut the states of all zones in the home
+func (h *Home) GetZoneStates(ctx context.Context) (*ZoneStates, error) {
+	zoneStates := &ZoneStates{}
+	if err := h.client.get(ctx, apiURL("homes/%d/zoneStates", h.ID), &zoneStates); err != nil {
+		return nil, err
+	}
+	return zoneStates, nil
+}
+
 // GetWeather returns weather information at the homes location
 func (h *Home) GetWeather(ctx context.Context) (*Weather, error) {
 	weather := &Weather{}

--- a/models.go
+++ b/models.go
@@ -200,6 +200,10 @@ type ZoneState struct {
 	SensorDataPoints               *ZoneStateSensorDataPoints    `json:"sensorDataPoints"`
 }
 
+type ZoneStates struct {
+	ZoneStates map[int32]*ZoneState `json:"zoneStates"`
+}
+
 // Power specifies is something is powered on or off
 type Power string
 


### PR DESCRIPTION
Thank you for this great library. There is an additional rest endpoint for getting the state of all zones at once. My application would benefit from fewer requests with this call. So here the proposal to add it to the Home type. 